### PR TITLE
feat(auth): implement failed login tracking and brute-force protectio…

### DIFF
--- a/docs/summaries/issue-68-track-failed-login-summary.md
+++ b/docs/summaries/issue-68-track-failed-login-summary.md
@@ -1,0 +1,33 @@
+# Issue Summary: Track Failed Login Attempts (#68)
+
+## Overview
+Implemented a mechanism to track failed login attempts, recording the IP address and timestamp for each failure, and locking the account after 5 failed attempts.
+
+## Changes Made
+### Domain & Application
+- Updated `LoginAttemptService` and `AuthService` to include IP address in the login flow.
+- Updated `AuthenticateUser` use case and `AuthUseCases` facade to propagate the IP address.
+
+### Infrastructure
+- `LoginAttemptServiceImpl`: Persists `lastFailedLoginIp` and `lastFailedLoginAt`. Locks `accountNonLocked` when `failedLoginAttempts >= 5`.
+- `AuthServiceImpl`: Captures IP and orchestrates success/failure recording.
+
+### Entry (REST)
+- `AuthController`: Extracts IP from `HttpServletRequest`.
+
+## Platform Updates
+- No new validators or error handlers were needed as existing ones were sufficient.
+
+## Security Impact
+- Provides brute-force protection via account locking.
+- Enhanced auditing with IP tracking.
+
+## Testing Results
+- **Integration Tests**: `LoginTrackingIntegrationTest` passed (3 tests).
+- **Controller Tests**: `AuthControllerTest` passed (2 tests).
+
+## API Usage
+- **Endpoint**: `POST /auth/login`
+- **Request Body**: `{ "email": "...", "password": "..." }`
+- **Headers**: The client's IP is automatically captured from the connection.
+- **Behavior**: Returns `401 Unauthorized` on failure (message: `auth.error.invalid_credentials`). Returns `403 Forbidden` after 5 failures (message: `auth.error.account_locked`).

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/application/usecase/AuthUseCases.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/application/usecase/AuthUseCases.java
@@ -62,8 +62,8 @@ public class AuthUseCases {
         return getAuthUserByUserName.execute(username);
     }
 
-    public AuthResponseDTO login(String email, String password) {
-        return authenticateUser.execute(email, password);
+    public AuthResponseDTO login(String email, String password, String ip) {
+        return authenticateUser.execute(email, password, ip);
     }
 
     public AuthResponseDTO register(AuthUser authUser) {

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/application/usecase/AuthenticateUser.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/application/usecase/AuthenticateUser.java
@@ -12,7 +12,7 @@ public class AuthenticateUser {
         this.authService = authService;
     }
 
-    public AuthResponseDTO execute(String email, String password) {
-        return authService.login(email, password);
+    public AuthResponseDTO execute(String email, String password, String ip) {
+        return authService.login(email, password, ip);
     }
 }

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/domain/service/AuthService.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/domain/service/AuthService.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface AuthService {
-    AuthResponseDTO login(String email, String password);
+    AuthResponseDTO login(String email, String password, String ip);
 
     AuthResponseDTO register(AuthUser auth, UUID id);
 

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/domain/service/LoginAttemptService.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/domain/service/LoginAttemptService.java
@@ -3,6 +3,6 @@ package com.socialseed.authservice.auth.domain.service;
 import java.util.UUID;
 
 public interface LoginAttemptService {
-    void recordFailedLogin(UUID userId);
-    void recordSuccessfulLogin(UUID userId);
+    void recordFailedLogin(UUID userId, String ip);
+    void recordSuccessfulLogin(UUID userId, String ip);
 }

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/entry/rest/controller/AuthController.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/entry/rest/controller/AuthController.java
@@ -120,8 +120,12 @@ public class AuthController {
 
         // region Log IN/OUT
         @PostMapping("/login")
-        public ResponseEntity<ApiResponse<?>> login(@Valid @RequestBody LoginRequestDTO request, Locale locale) {
-                AuthResponseDTO response = authUseCases.login(request.email(), request.password());
+        public ResponseEntity<ApiResponse<?>> login(
+                        @Valid @RequestBody LoginRequestDTO request,
+                        jakarta.servlet.http.HttpServletRequest httpRequest,
+                        Locale locale) {
+                String ip = httpRequest.getRemoteAddr();
+                AuthResponseDTO response = authUseCases.login(request.email(), request.password(), ip);
                 return ResponseEntity.ok(
                                 ApiResponse.success(
                                                 response,

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/infrastructure/service/AuthServiceImpl.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/infrastructure/service/AuthServiceImpl.java
@@ -61,7 +61,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public AuthResponseDTO login(String email, String password) {
+    public AuthResponseDTO login(String email, String password, String ip) {
         AuthUser authUser = authUserRepository.findByEmail(email)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
 
@@ -72,12 +72,12 @@ public class AuthServiceImpl implements AuthService {
 
         if (!passwordEncoder.matches(password, authUser.getPassword())) {
             // Record failed login in separate transaction
-            loginAttemptService.recordFailedLogin(authUser.getId());
+            loginAttemptService.recordFailedLogin(authUser.getId(), ip);
             throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
         }
 
         // Record successful login
-        loginAttemptService.recordSuccessfulLogin(authUser.getId());
+        loginAttemptService.recordSuccessfulLogin(authUser.getId(), ip);
 
         String token = jwtProvider.generateToken(authUser.getUsername());
         RefreshToken refreshToken = RefreshToken.create(authUser.getId(), refreshTokenDurationSeconds);

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/infrastructure/service/LoginAttemptServiceImpl.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/infrastructure/service/LoginAttemptServiceImpl.java
@@ -21,11 +21,12 @@ public class LoginAttemptServiceImpl implements LoginAttemptService {
 
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void recordFailedLogin(UUID userId) {
+    public void recordFailedLogin(UUID userId, String ip) {
         AuthUser authUser = authUserRepository.findById(userId).orElseThrow();
         
         authUser.setFailedLoginAttempts(authUser.getFailedLoginAttempts() + 1);
         authUser.setLastFailedLoginAt(Instant.now());
+        authUser.setLastFailedLoginIp(ip);
         
         // Lock account after 5 failed attempts
         if (authUser.getFailedLoginAttempts() >= 5) {
@@ -37,10 +38,11 @@ public class LoginAttemptServiceImpl implements LoginAttemptService {
 
     @Override
     @Transactional
-    public void recordSuccessfulLogin(UUID userId) {
+    public void recordSuccessfulLogin(UUID userId, String ip) {
         AuthUser authUser = authUserRepository.findById(userId).orElseThrow();
         
         authUser.setLastLoginAt(Instant.now());
+        authUser.setLastLoginIp(ip);
         authUser.setFailedLoginAttempts(0);
         authUser.setLastFailedLoginAt(null);
         

--- a/services/auth-service/src/test/java/com/socialseed/authservice/auth/entry/rest/controller/AuthControllerTest.java
+++ b/services/auth-service/src/test/java/com/socialseed/authservice/auth/entry/rest/controller/AuthControllerTest.java
@@ -31,6 +31,23 @@ class AuthControllerTest {
 
     @Test
     @WithMockUser
+    void shouldLoginSuccessfully() throws Exception {
+        com.socialseed.authservice.auth.entry.rest.dto.LoginRequestDTO loginRequest = 
+            new com.socialseed.authservice.auth.entry.rest.dto.LoginRequestDTO("test@example.com", "Password123!");
+        
+        mockMvc.perform(post("/auth/login")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk());
+
+        verify(authUseCases).login(org.mockito.ArgumentMatchers.eq("test@example.com"), 
+                                    org.mockito.ArgumentMatchers.eq("Password123!"), 
+                                    org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    @WithMockUser
     void shouldLogoutSuccessfully() throws Exception {
         LogoutRequestDTO logoutRequest = new LogoutRequestDTO("valid-refresh-token");
         String accessToken = "Bearer valid-access-token";

--- a/services/auth-service/src/test/java/com/socialseed/authservice/auth/infrastructure/service/LoginTrackingIntegrationTest.java
+++ b/services/auth-service/src/test/java/com/socialseed/authservice/auth/infrastructure/service/LoginTrackingIntegrationTest.java
@@ -1,0 +1,98 @@
+package com.socialseed.authservice.auth.infrastructure.service;
+
+import com.socialseed.authservice.auth.domain.model.AuthUser;
+import com.socialseed.authservice.auth.domain.repository.AuthUserRepository;
+import com.socialseed.authservice.auth.domain.service.AuthService;
+import com.socialseed.errorhandling.exception.BusinessException;
+import com.socialseed.errorhandling.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class LoginTrackingIntegrationTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private AuthUserRepository authUserRepository;
+
+    @Autowired
+    private com.socialseed.authservice.auth.infrastructure.persistence.pgsql.repository.AuthUserPgsqlRepository jpaRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private UUID userId;
+    private String email = "test@example.com";
+    private String password = "Password123!";
+    private String ip = "192.168.1.1";
+
+    @BeforeEach
+    void setUp() {
+        jpaRepository.deleteAll();
+        userId = UUID.randomUUID();
+        AuthUser user = new AuthUser(userId, "testuser", email, passwordEncoder.encode(password));
+        authUserRepository.save(user);
+    }
+
+    @Test
+    void shouldIncrementFailedAttemptsOnInvalidPassword() {
+        assertThatThrownBy(() -> authService.login(email, "wrongpassword", ip))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("auth.error.invalid_credentials");
+
+        AuthUser updatedUser = authUserRepository.findByEmail(email).orElseThrow();
+        assertThat(updatedUser.getFailedLoginAttempts()).isEqualTo(1);
+        assertThat(updatedUser.getLastFailedLoginIp()).isEqualTo(ip);
+        assertThat(updatedUser.getLastFailedLoginAt()).isNotNull();
+    }
+
+    @Test
+    void shouldLockAccountAfterFiveFailedAttempts() {
+        for (int i = 1; i <= 5; i++) {
+            assertThatThrownBy(() -> authService.login(email, "wrongpassword", ip))
+                .isInstanceOf(BusinessException.class);
+        }
+
+        AuthUser updatedUser = authUserRepository.findByEmail(email).orElseThrow();
+        assertThat(updatedUser.getFailedLoginAttempts()).isEqualTo(5);
+        assertThat(updatedUser.isAccountNonLocked()).isFalse();
+
+        assertThatThrownBy(() -> authService.login(email, password, ip))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("auth.error.account_locked");
+    }
+
+    @Test
+    void shouldResetFailedAttemptsOnSuccessfulLogin() {
+        // Record some failures
+        assertThatThrownBy(() -> authService.login(email, "wrongpassword", ip))
+                .isInstanceOf(BusinessException.class);
+        assertThatThrownBy(() -> authService.login(email, "wrongpassword", ip))
+                .isInstanceOf(BusinessException.class);
+
+        AuthUser userWithFailures = authUserRepository.findByEmail(email).orElseThrow();
+        assertThat(userWithFailures.getFailedLoginAttempts()).isEqualTo(2);
+
+        // Successful login
+        authService.login(email, password, "10.0.0.1");
+
+        AuthUser successfulUser = authUserRepository.findByEmail(email).orElseThrow();
+        assertThat(successfulUser.getFailedLoginAttempts()).isEqualTo(0);
+        assertThat(successfulUser.getLastLoginIp()).isEqualTo("10.0.0.1");
+        assertThat(successfulUser.getLastLoginAt()).isNotNull();
+        assertThat(successfulUser.getLastFailedLoginAt()).isNull();
+    }
+}

--- a/verify_services/verify_auth_flow.py
+++ b/verify_services/verify_auth_flow.py
@@ -193,6 +193,30 @@ def run_verification():
     else:
         print(f"  ERROR: Unexpected status for invalid token: {resp.status_code}")
 
+    # 11. Brute Force Mitigation Flow
+    print("\n11. Brute Force Mitigation Flow")
+    unique_suffix = int(time.time())
+    BRUTE_EMAIL = f"brute_{unique_suffix}@test.com"
+    BRUTE_ID = str(java.util.UUID.randomUUID()) if 'java' in globals() else f"11111111-2222-3333-4444-{unique_suffix % 1000000000000:012d}"
+    register(BRUTE_ID, f"bruteuser_{unique_suffix}", BRUTE_EMAIL, "Password123!")
+    
+    print("  Attempting 5 failed logins to lock the account...")
+    for i in range(5):
+        resp = login(BRUTE_EMAIL, "WrongPass1!")
+        if resp.status_code == 401:
+            print(f"    Attempt {i+1}: Rejected as expected (401).")
+        else:
+            print(f"    ERROR: Attempt {i+1} got unexpected status {resp.status_code}")
+            sys.exit(1)
+            
+    print("  Attempting login with correct password (should be locked)...")
+    resp = login(BRUTE_EMAIL, "Password123!")
+    if resp.status_code == 403:
+        print("    Account successfully locked (403 Forbidden).")
+    else:
+        print(f"    ERROR: Account not locked! Status: {resp.status_code}, Body: {resp.text}")
+        sys.exit(1)
+
     print("\n--- ALL TESTS COMPLETED SUCCESSFULLY ---")
 
 if __name__ == "__main__":


### PR DESCRIPTION
feat(auth): implement failed login tracking and brute-force protection (#68)

- Track client IP address on every login attempt (success/failure).
- Record timestamp of failed login attempts.
- Automatically lock account after 5 consecutive failed attempts.
- Reset counter upon successful login.
- Added integration tests in Java and E2E validation in Python.
- Included issue summary documentation.