### PR TITLE
refactor(auth): clean domain models and ensure hexagonal boundaries (#100)

### DIFF
--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/application/usecase/AuthUseCases.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/application/usecase/AuthUseCases.java
@@ -1,7 +1,7 @@
 package com.socialseed.authservice.auth.application.usecase;
 
+import com.socialseed.authservice.auth.domain.model.AuthResult;
 import com.socialseed.authservice.auth.domain.model.AuthUser;
-import com.socialseed.authservice.auth.entry.rest.dto.AuthResponseDTO;
 import jakarta.validation.Valid;
 import org.springframework.stereotype.Service;
 
@@ -62,11 +62,11 @@ public class AuthUseCases {
         return getAuthUserByUserName.execute(username);
     }
 
-    public AuthResponseDTO login(String email, String password, String ip) {
+    public AuthResult login(String email, String password, String ip) {
         return authenticateUser.execute(email, password, ip);
     }
 
-    public AuthResponseDTO register(AuthUser authUser) {
+    public AuthResult register(AuthUser authUser) {
         return registerUser.execute(authUser);
     }
 
@@ -78,7 +78,7 @@ public class AuthUseCases {
         logout.execute(accessToken, refreshToken);
     }
 
-    public AuthResponseDTO refreshToken(String token) {
+    public AuthResult refreshToken(String token) {
         return refreshToken.execute(token);
     }
 

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/application/usecase/AuthenticateUser.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/application/usecase/AuthenticateUser.java
@@ -1,7 +1,7 @@
 package com.socialseed.authservice.auth.application.usecase;
 
+import com.socialseed.authservice.auth.domain.model.AuthResult;
 import com.socialseed.authservice.auth.domain.service.AuthService;
-import com.socialseed.authservice.auth.entry.rest.dto.AuthResponseDTO;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,7 +12,7 @@ public class AuthenticateUser {
         this.authService = authService;
     }
 
-    public AuthResponseDTO execute(String email, String password, String ip) {
+    public AuthResult execute(String email, String password, String ip) {
         return authService.login(email, password, ip);
     }
 }

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/application/usecase/RefreshToken.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/application/usecase/RefreshToken.java
@@ -1,7 +1,7 @@
 package com.socialseed.authservice.auth.application.usecase;
 
+import com.socialseed.authservice.auth.domain.model.AuthResult;
 import com.socialseed.authservice.auth.domain.service.AuthService;
-import com.socialseed.authservice.auth.entry.rest.dto.AuthResponseDTO;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,7 +12,7 @@ public class RefreshToken {
         this.authService = authService;
     }
 
-    public AuthResponseDTO execute(String refreshToken) {
+    public AuthResult execute(String refreshToken) {
         return authService.refreshToken(refreshToken);
     }
 }

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/application/usecase/RegisterUser.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/application/usecase/RegisterUser.java
@@ -1,8 +1,8 @@
 package com.socialseed.authservice.auth.application.usecase;
 
+import com.socialseed.authservice.auth.domain.model.AuthResult;
 import com.socialseed.authservice.auth.domain.model.AuthUser;
 import com.socialseed.authservice.auth.domain.service.AuthService;
-import com.socialseed.authservice.auth.entry.rest.dto.AuthResponseDTO;
 import com.socialseed.errorhandling.exception.BusinessException;
 import com.socialseed.errorhandling.exception.ErrorCode;
 import com.socialseed.contracts.socialuser.SocialUserServiceGrpc;
@@ -29,7 +29,7 @@ public class RegisterUser {
         this.socialUserClient = SocialUserServiceGrpc.newBlockingStub(channel);
     }
 
-    public AuthResponseDTO execute(AuthUser authUser) {
+    public AuthResult execute(AuthUser authUser) {
         log.info("Starting user registration for email: {}", authUser.getEmail());
 
         // 1️Crar el usuario social vía gRPC

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/domain/model/AuthResult.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/domain/model/AuthResult.java
@@ -1,0 +1,9 @@
+package com.socialseed.authservice.auth.domain.model;
+
+import java.util.Set;
+
+public record AuthResult(
+    String token,
+    String refreshToken,
+    Set<String> roles
+) {}

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/domain/model/AuthUser.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/domain/model/AuthUser.java
@@ -1,7 +1,5 @@
 package com.socialseed.authservice.auth.domain.model;
 
-import jakarta.validation.constraints.NotNull;
-
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
@@ -10,13 +8,10 @@ import java.util.UUID;
 public class AuthUser {
     private UUID id;
 
-    @NotNull
     private String username;
 
-    @NotNull
     private String email;
 
-    @NotNull
     private String password;
 
     private Set<String> roles = new HashSet<>();

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/domain/service/AuthService.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/domain/service/AuthService.java
@@ -1,15 +1,15 @@
 package com.socialseed.authservice.auth.domain.service;
 
+import com.socialseed.authservice.auth.domain.model.AuthResult;
 import com.socialseed.authservice.auth.domain.model.AuthUser;
-import com.socialseed.authservice.auth.entry.rest.dto.AuthResponseDTO;
 
 import java.util.Optional;
 import java.util.UUID;
 
 public interface AuthService {
-    AuthResponseDTO login(String email, String password, String ip);
+    AuthResult login(String email, String password, String ip);
 
-    AuthResponseDTO register(AuthUser auth, UUID id);
+    AuthResult register(AuthUser auth, UUID id);
 
     Optional<AuthUser> getUserById(UUID id);
 
@@ -25,7 +25,7 @@ public interface AuthService {
 
     void logout(String accessToken, String refreshToken);
 
-    AuthResponseDTO refreshToken(String refreshToken);
+    AuthResult refreshToken(String refreshToken);
 
     void verifyEmail(String token);
 

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/entry/rest/controller/AuthController.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/entry/rest/controller/AuthController.java
@@ -90,7 +90,7 @@ public class AuthController {
         @PostMapping("/register")
         public ResponseEntity<ApiResponse<?>> register(@Valid @RequestBody RegisterRequestDTO request, Locale locale) {
                 AuthUser authUser = AuthRestMapper.toDomain(request);
-                AuthResponseDTO response = authUseCases.register(authUser);
+                AuthResponseDTO response = AuthRestMapper.toResponse(authUseCases.register(authUser));
                 return ResponseEntity
                                 .status(HttpStatus.CREATED)
                                 .body(
@@ -125,7 +125,7 @@ public class AuthController {
                         jakarta.servlet.http.HttpServletRequest httpRequest,
                         Locale locale) {
                 String ip = httpRequest.getRemoteAddr();
-                AuthResponseDTO response = authUseCases.login(request.email(), request.password(), ip);
+                AuthResponseDTO response = AuthRestMapper.toResponse(authUseCases.login(request.email(), request.password(), ip));
                 return ResponseEntity.ok(
                                 ApiResponse.success(
                                                 response,
@@ -146,7 +146,7 @@ public class AuthController {
     @PostMapping("/token/refresh")
         public ResponseEntity<ApiResponse<?>> refreshToken(@Valid @RequestBody RefreshTokenRequestDTO request,
                         Locale locale) {
-                AuthResponseDTO response = authUseCases.refreshToken(request.refreshToken());
+                AuthResponseDTO response = AuthRestMapper.toResponse(authUseCases.refreshToken(request.refreshToken()));
                 return ResponseEntity.ok(
                                 ApiResponse.success(
                                                 response,

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/entry/rest/mapper/AuthRestMapper.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/entry/rest/mapper/AuthRestMapper.java
@@ -1,6 +1,8 @@
 package com.socialseed.authservice.auth.entry.rest.mapper;
 
+import com.socialseed.authservice.auth.domain.model.AuthResult;
 import com.socialseed.authservice.auth.domain.model.AuthUser;
+import com.socialseed.authservice.auth.entry.rest.dto.AuthResponseDTO;
 import com.socialseed.authservice.auth.entry.rest.dto.AuthUserResponseDTO;
 import com.socialseed.authservice.auth.entry.rest.dto.RegisterRequestDTO;
 
@@ -34,6 +36,14 @@ public class AuthRestMapper {
                 user.getCreatedAt(),
                 user.getUpdatedAt(),
                 user.getLastLoginAt()
+        );
+    }
+
+    public static AuthResponseDTO toResponse(AuthResult result) {
+        return new AuthResponseDTO(
+                result.token(),
+                result.refreshToken(),
+                result.roles()
         );
     }
 }

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/infrastructure/service/AuthServiceImpl.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/infrastructure/service/AuthServiceImpl.java
@@ -4,6 +4,7 @@ import com.socialseed.authservice.auth.config.jwt.JWTProvider;
 import com.socialseed.authservice.auth.domain.event.PasswordChangedEvent;
 import com.socialseed.authservice.auth.domain.event.UserRegisteredEvent;
 import com.socialseed.authservice.auth.domain.repository.PasswordChangedEventPublisher;
+import com.socialseed.authservice.auth.domain.model.AuthResult;
 import com.socialseed.authservice.auth.domain.model.AuthUser;
 import com.socialseed.authservice.auth.domain.repository.AuthUserRepository;
 import com.socialseed.authservice.auth.domain.repository.RefreshTokenRepository;
@@ -11,7 +12,6 @@ import com.socialseed.authservice.auth.domain.repository.UserRegisteredEventPubl
 import com.socialseed.authservice.auth.domain.service.AuthService;
 import com.socialseed.authservice.auth.domain.service.TokenBlacklistService;
 import com.socialseed.authservice.auth.domain.model.RefreshToken;
-import com.socialseed.authservice.auth.entry.rest.dto.AuthResponseDTO;
 import com.socialseed.errorhandling.exception.BusinessException;
 import com.socialseed.errorhandling.exception.ErrorCode;
 import jakarta.transaction.Transactional;
@@ -61,7 +61,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public AuthResponseDTO login(String email, String password, String ip) {
+    public AuthResult login(String email, String password, String ip) {
         AuthUser authUser = authUserRepository.findByEmail(email)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
 
@@ -85,12 +85,12 @@ public class AuthServiceImpl implements AuthService {
 
         Set<String> roles = authUser.getRoles();
 
-        return new AuthResponseDTO(token, refreshToken.getToken(), roles);
+        return new AuthResult(token, refreshToken.getToken(), roles);
     }
 
     @Transactional
     @Override
-    public AuthResponseDTO register(AuthUser authUser, UUID id) {
+    public AuthResult register(AuthUser authUser, UUID id) {
 
         AuthUser newAuthUser = new AuthUser(
                 id,
@@ -126,7 +126,7 @@ public class AuthServiceImpl implements AuthService {
 
         Set<String> roles = newAuthUser.getRoles();
 
-        return new AuthResponseDTO(token, refreshToken.getToken(), roles);
+        return new AuthResult(token, refreshToken.getToken(), roles);
     }
 
     @Override
@@ -210,7 +210,7 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     @Transactional
-    public AuthResponseDTO refreshToken(String token) {
+    public AuthResult refreshToken(String token) {
         RefreshToken refreshToken = refreshTokenRepository.findByToken(token)
                 .orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
 
@@ -239,7 +239,7 @@ public class AuthServiceImpl implements AuthService {
         refreshTokenRepository.save(newRefreshToken);
 
 
-        return new AuthResponseDTO(newAccessToken, newRefreshToken.getToken(), authUser.getRoles());
+        return new AuthResult(newAccessToken, newRefreshToken.getToken(), authUser.getRoles());
     }
 
     @Override

--- a/services/auth-service/src/test/java/com/socialseed/authservice/auth/entry/rest/controller/AuthControllerTest.java
+++ b/services/auth-service/src/test/java/com/socialseed/authservice/auth/entry/rest/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.socialseed.authservice.auth.entry.rest.controller;
 
 import com.socialseed.authservice.auth.application.usecase.AuthUseCases;
+import com.socialseed.authservice.auth.domain.model.AuthResult;
 import com.socialseed.authservice.auth.entry.rest.dto.LogoutRequestDTO;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,11 @@ class AuthControllerTest {
     void shouldLoginSuccessfully() throws Exception {
         com.socialseed.authservice.auth.entry.rest.dto.LoginRequestDTO loginRequest = 
             new com.socialseed.authservice.auth.entry.rest.dto.LoginRequestDTO("test@example.com", "Password123!");
+        
+        org.mockito.BDDMockito.given(authUseCases.login(org.mockito.ArgumentMatchers.anyString(), 
+                org.mockito.ArgumentMatchers.anyString(), 
+                org.mockito.ArgumentMatchers.anyString()))
+            .willReturn(new AuthResult("token", "refresh", java.util.Set.of("ROLE_USER")));
         
         mockMvc.perform(post("/auth/login")
                         .with(csrf())

--- a/services/auth-service/src/test/java/com/socialseed/authservice/auth/infrastructure/service/RefreshTokenServiceTest.java
+++ b/services/auth-service/src/test/java/com/socialseed/authservice/auth/infrastructure/service/RefreshTokenServiceTest.java
@@ -1,6 +1,7 @@
 package com.socialseed.authservice.auth.infrastructure.service;
 
 import com.socialseed.authservice.auth.config.jwt.JWTProvider;
+import com.socialseed.authservice.auth.domain.model.AuthResult;
 import com.socialseed.authservice.auth.domain.model.AuthUser;
 import com.socialseed.authservice.auth.domain.model.RefreshToken;
 import com.socialseed.authservice.auth.domain.repository.AuthUserRepository;
@@ -8,7 +9,13 @@ import com.socialseed.authservice.auth.domain.repository.RefreshTokenRepository;
 import com.socialseed.authservice.auth.domain.repository.PasswordChangedEventPublisher;
 import com.socialseed.authservice.auth.domain.repository.UserRegisteredEventPublisher;
 import com.socialseed.authservice.auth.domain.service.TokenBlacklistService;
-import com.socialseed.authservice.auth.entry.rest.dto.AuthResponseDTO;
+import com.socialseed.authservice.auth.infrastructure.service.AuthServiceImpl;
+import com.socialseed.authservice.auth.domain.repository.AuthUserRepository;
+import com.socialseed.authservice.auth.domain.repository.RefreshTokenRepository;
+import com.socialseed.authservice.auth.domain.repository.PasswordChangedEventPublisher;
+import com.socialseed.authservice.auth.domain.repository.UserRegisteredEventPublisher;
+import com.socialseed.authservice.auth.domain.service.TokenBlacklistService;
+import com.socialseed.authservice.auth.infrastructure.service.AuthServiceImpl;
 import com.socialseed.errorhandling.exception.BusinessException;
 import com.socialseed.errorhandling.exception.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -84,7 +91,7 @@ class RefreshTokenServiceTest {
         when(jwtProvider.generateToken(any())).thenReturn("new-access-token");
 
         // Act
-        AuthResponseDTO response = authService.refreshToken(oldTokenStr);
+        AuthResult response = authService.refreshToken(oldTokenStr);
 
         // Assert
         assertNotNull(response);


### PR DESCRIPTION
…#100)

- Removed Jakarta validation annotations from AuthUser domain model.
- Introduced AuthResult domain model to decouple Application and Domain layers from Entry layer DTOs.
- Updated AuthService interface and implementation to use AuthResult.
- Updated application use cases (AuthenticateUser, RegisterUser, RefreshToken) to return AuthResult.
- Implemented mapping logic in AuthRestMapper to bridge AuthResult and AuthResponseDTO.
- Updated unit and integration tests to reflect architectural changes and types.
- Verified system integrity with 33 Java tests and full E2E Python verification.