### PR TITLE
feat: List User Roles (#79)

### DIFF
--- a/docs/summaries/issue-79-list-user-roles-summary.md
+++ b/docs/summaries/issue-79-list-user-roles-summary.md
@@ -1,0 +1,32 @@
+# Issue Summary: List User Roles (#79)
+
+## Overview
+Implemented a secured endpoint `GET /auth/{id}/roles` to allow users and admins to view assigned roles.
+
+## Endpoints
+- `GET /auth/{id}/roles`: Returns a list of roles (e.g., `["ROLE_USER", "ROLE_ADMIN"]`).
+
+## Security Policy
+- **Admin**: Can view roles for any `id`.
+- **Self**: Can view roles if the authenticated user's ID matches the requested `id` (via username ownership check).
+- **Others**: 403 Forbidden.
+- **Unauthenticated**: 401 Unauthorized.
+
+## Usage Example
+```bash
+curl -X GET http://localhost:8081/auth/{user-id}/roles \
+  -H "Authorization: Bearer <access-token>"
+```
+
+## Response
+```json
+{
+  "status": 200,
+  "data": [
+    "ROLE_USER"
+  ],
+  "message": "User roles retrieved successfully",
+  "version": "v0.0.1",
+  "timestamp": "..."
+}
+```

--- a/platform/socialseed-api-response-starter/src/main/resources/messages.properties
+++ b/platform/socialseed-api-response-starter/src/main/resources/messages.properties
@@ -114,3 +114,4 @@ auth.error.verification_token_invalid=Invalid verification token
 auth.error.verification_token_expired=Verification token has expired
 auth.error.email_already_verified=Email is already verified
 auth.error.password_expired=Your password has expired and must be changed.
+auth.roles.list.success=User roles retrieved successfully

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/application/usecase/AuthUseCases.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/application/usecase/AuthUseCases.java
@@ -22,6 +22,7 @@ public class AuthUseCases {
     public final ResetPassword resetPassword;
     private final VerifyEmail verifyEmail;
     private final ResendVerificationEmail resendVerificationEmail;
+    public final GetUserRoles getUserRoles;
 
     public AuthUseCases(
             AuthenticateUser authenticateUser,
@@ -35,7 +36,8 @@ public class AuthUseCases {
             ForgotPassword forgotPassword,
             ResetPassword resetPassword,
             VerifyEmail verifyEmail,
-            ResendVerificationEmail resendVerificationEmail) {
+            ResendVerificationEmail resendVerificationEmail,
+            GetUserRoles getUserRoles) {
         this.authenticateUser = authenticateUser;
         this.registerUser = registerUser;
         this.changeUserPassword = changeUserPassword;
@@ -48,6 +50,7 @@ public class AuthUseCases {
         this.resetPassword = resetPassword;
         this.verifyEmail = verifyEmail;
         this.resendVerificationEmail = resendVerificationEmail;
+        this.getUserRoles = getUserRoles;
     }
 
     public Optional<AuthUser> getAuthUserById(UUID userId) {
@@ -96,5 +99,9 @@ public class AuthUseCases {
 
     public void resendVerificationEmail(String email) {
         resendVerificationEmail.execute(email);
+    }
+
+    public java.util.Set<String> getUserRoles(java.util.UUID userId) {
+        return getUserRoles.execute(userId);
     }
 }

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/application/usecase/GetUserRoles.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/application/usecase/GetUserRoles.java
@@ -1,0 +1,25 @@
+package com.socialseed.authservice.auth.application.usecase;
+
+import com.socialseed.authservice.auth.domain.model.AuthUser;
+import com.socialseed.authservice.auth.domain.service.AuthService;
+import com.socialseed.errorhandling.exception.BusinessException;
+import com.socialseed.errorhandling.exception.ErrorCode;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class GetUserRoles {
+    private final AuthService authService;
+
+    public GetUserRoles(AuthService authService) {
+        this.authService = authService;
+    }
+
+    public Set<String> execute(UUID userId) {
+        AuthUser user = authService.getUserById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        return user.getRoles();
+    }
+}

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/config/jwt/JwtAuthFilter.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/config/jwt/JwtAuthFilter.java
@@ -24,7 +24,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
     private final List<String> excludedPaths = List.of(
             "/about",
-            "/auth/**",
+//            "/auth/**", // Allow filter to run for auth endpoints (e.g., /auth/{id}/roles)
             "/public/**",
             "/assets/**",
             "/swagger-ui/**",

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/entry/rest/controller/AuthController.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/entry/rest/controller/AuthController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 @RestController
@@ -84,6 +85,51 @@ public class AuthController {
                                                 ApiResponse.message(
                                                                 HttpStatus.NOT_FOUND.value(),
                                                                 "User by UserName not found"));
+        }
+
+        @GetMapping("/{id}/roles")
+        public ResponseEntity<ApiResponse<?>> getUserRoles(
+                @PathVariable UUID id,
+                Locale locale,
+                org.springframework.security.core.Authentication authentication) {
+
+                if (authentication == null || !authentication.isAuthenticated() || "anonymousUser".equals(authentication.getPrincipal())) {
+                        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+                }
+
+                // Security Check
+                // 1. Is Admin?
+                boolean isAdmin = authentication.getAuthorities().stream()
+                        .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
+                
+                // 2. Is Self?
+                // Assuming the principal username matches the username in DB, we need to map username to ID or AuthUser.
+                // Wait, JwtAuthFilter sets UserDetails.
+                // Let's assume username is available.
+                // It is better to rely on `authentication.getName()` which should return username.
+                // We need to fetch the user by username to compare ID, OR fetch user by requested ID and compare username.
+                // Since fetching user happens in use case, maybe we can do a quick check here if we have the info.
+                
+                // Better approach: Let AuthUseCases handle the logic? No, Security is usually Controller or Filter.
+                
+                // Let's fetch the requested user to check ownership
+                // Optimize: check ownership only if not admin.
+                if (!isAdmin) {
+                    AuthUser reqUser = authUseCases.getAuthUserById(id)
+                            .orElseThrow(() -> new com.socialseed.errorhandling.exception.BusinessException(com.socialseed.errorhandling.exception.ErrorCode.USER_NOT_FOUND));
+                    
+                    if (!reqUser.getUsername().equals(authentication.getName())) {
+                         return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+                    }
+                }
+
+                Set<String> roles = authUseCases.getUserRoles(id);
+                return ResponseEntity.ok(
+                        ApiResponse.success(
+                                roles,
+                                messageSource.getMessage("auth.roles.list.success", null, locale)
+                        )
+                );
         }
         // endregion
 

--- a/services/auth-service/src/test/java/com/socialseed/authservice/GetUserRolesIntegrationTest.java
+++ b/services/auth-service/src/test/java/com/socialseed/authservice/GetUserRolesIntegrationTest.java
@@ -1,0 +1,78 @@
+package com.socialseed.authservice;
+
+import com.socialseed.authservice.auth.domain.model.AuthUser;
+import com.socialseed.authservice.auth.infrastructure.persistence.pgsql.repository.AuthUserPgsqlRepository;
+import com.socialseed.authservice.auth.infrastructure.service.AuthServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class GetUserRolesIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private AuthServiceImpl authService;
+
+    @Autowired
+    private AuthUserPgsqlRepository authUserRepository;
+
+    private UUID userId;
+    private final String username = "testuser";
+    private final String email = "testuser@example.com";
+
+    @BeforeEach
+    void setUp() {
+        authUserRepository.deleteAll();
+        userId = UUID.randomUUID();
+        AuthUser authUser = new AuthUser(userId, username, email, "Password123!");
+        authService.register(authUser, userId);
+    }
+
+    @Test
+    @WithMockUser(username = "testuser", roles = {"USER"})
+    void shouldReturnRolesForSelf() throws Exception {
+        mockMvc.perform(get("/auth/" + userId + "/roles"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0]").value("ROLE_USER"))
+                .andExpect(jsonPath("$.message").value("User roles retrieved successfully"));
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    void shouldReturnRolesForAdminEvaluatingAnyUser() throws Exception {
+        mockMvc.perform(get("/auth/" + userId + "/roles"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0]").value("ROLE_USER"));
+    }
+
+    @Test
+    @WithMockUser(username = "otheruser", roles = {"USER"})
+    void shouldForbidAccessToOtherUserRoles() throws Exception {
+        mockMvc.perform(get("/auth/" + userId + "/roles"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void shouldReturnUnauthorizedForAnonymous() throws Exception {
+        mockMvc.perform(get("/auth/" + userId + "/roles"))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
# Issue Summary: List User Roles (#79)

## Overview
Implemented a secured endpoint `GET /auth/{id}/roles` to allow users and admins to view assigned roles.

## Endpoints
- `GET /auth/{id}/roles`: Returns a list of roles (e.g., `["ROLE_USER", "ROLE_ADMIN"]`).

## Security Policy
- **Admin**: Can view roles for any `id`.
- **Self**: Can view roles if the authenticated user's ID matches the requested `id` (via username ownership check).
- **Others**: 403 Forbidden.
- **Unauthenticated**: 401 Unauthorized.