### PR TITLE
feat: implement verify email workflow (#66)

### DIFF
--- a/docs/summaries/issue-66-verify-email-workflow-summary.md
+++ b/docs/summaries/issue-66-verify-email-workflow-summary.md
@@ -1,0 +1,52 @@
+# Issue 66: Implement Verify Email Workflow - Summary
+
+## Overview
+Implementación completa del flujo de verificación de email que permite marcar usuarios como verificados, emitir eventos y registrar auditoría.
+
+## Changes Made
+
+### Platform (Centralized Contracts)
+- **auth_events.proto**: Se añadió el mensaje `AuthUserEmailVerified` para el tópico `auth.user.email.verified`.
+
+### Auth-Service
+
+#### Controller
+- **AuthController**: Añadido nuevo endpoint `GET /auth/verify?token=...` para verificación de email vía URL (clickable links).
+- El endpoint `POST /auth/verify-email` se mantiene para compatibilidad con clientes existentes.
+
+#### Use Case
+- **VerifyEmail**: Actualizado para:
+    1. Validar token y su expiración.
+    2. Marcar `emailVerified = true` en el usuario.
+    3. Limpiar token (single-use).
+    4. **Audit Logging**: Registra eventos INFO para éxito y WARN para fallos.
+    5. **Kafka Event**: Emite `AuthUserEmailVerified` al tópico `auth.user.email.verified`.
+
+### Error Handling
+Los siguientes códigos de error estandarizados son usados:
+- `VERIFICATION_TOKEN_INVALID`: Token no encontrado (400 Bad Request).
+- `VERIFICATION_TOKEN_EXPIRED`: Token expirado (400 Bad Request).
+- `EMAIL_ALREADY_VERIFIED`: Email ya verificado (400 Bad Request).
+
+## Verification Results
+
+### Unit/Integration Testing
+Se ejecutaron 6 tests en `VerifyEmailIntegrationTest`:
+1. ✅ `shouldVerifyEmailSuccessfully` - Happy path POST
+2. ✅ `shouldVerifyEmailViaGetEndpoint` - Happy path GET
+3. ✅ `shouldFailWithInvalidToken` - Token inválido POST
+4. ✅ `shouldFailWithInvalidTokenViaGet` - Token inválido GET
+5. ✅ `shouldFailWithExpiredToken` - Token expirado
+6. ✅ `shouldFailIfAlreadyVerified` - Email ya verificado
+
+Todos los tests pasaron exitosamente.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET    | `/auth/verify?token={token}` | Verificar email (para links clickables) |
+| POST   | `/auth/verify-email` | Verificar email (body: `{"token": "..."}`) |
+
+## Conclusion
+El flujo de verificación de email está completo con todos los criterios de aceptación cumplidos: endpoint GET disponible, códigos de error estandarizados, evento Kafka emitido y audit logging implementado.

--- a/platform/socialseed-contracts/src/main/proto/auth_events.proto
+++ b/platform/socialseed-contracts/src/main/proto/auth_events.proto
@@ -42,3 +42,13 @@ message AuthUserEmailChanged {
     string new_email = 3;
     google.protobuf.Timestamp updated_at = 4;
 }
+
+/**
+ * Evento enviado al topic: auth.user.email.verified
+ * Representa que un usuario ha verificado exitosamente su email.
+ */
+message AuthUserEmailVerified {
+    string user_id = 1;
+    string email = 2;
+    google.protobuf.Timestamp verified_at = 3;
+}

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/application/usecase/VerifyEmail.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/application/usecase/VerifyEmail.java
@@ -2,8 +2,12 @@ package com.socialseed.authservice.auth.application.usecase;
 
 import com.socialseed.authservice.auth.domain.model.AuthUser;
 import com.socialseed.authservice.auth.domain.repository.AuthUserRepository;
+import com.socialseed.contracts.auth.events.AuthUserEmailVerified;
 import com.socialseed.errorhandling.exception.BusinessException;
 import com.socialseed.errorhandling.exception.ErrorCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
@@ -11,24 +15,35 @@ import java.time.Instant;
 @Component
 public class VerifyEmail {
 
-    private final AuthUserRepository authUserRepository;
+    private static final Logger logger = LoggerFactory.getLogger(VerifyEmail.class);
 
-    public VerifyEmail(AuthUserRepository authUserRepository) {
+    private final AuthUserRepository authUserRepository;
+    private final KafkaTemplate<String, byte[]> kafkaTemplate;
+
+    public VerifyEmail(AuthUserRepository authUserRepository, KafkaTemplate<String, byte[]> kafkaTemplate) {
         this.authUserRepository = authUserRepository;
+        this.kafkaTemplate = kafkaTemplate;
     }
 
     public void execute(String token) {
+        logger.info("Processing email verification for token: {}...", token.substring(0, Math.min(5, token.length())));
+
         AuthUser authUser = authUserRepository.findByVerificationToken(token)
-                .orElseThrow(() -> new BusinessException(ErrorCode.VERIFICATION_TOKEN_INVALID));
+                .orElseThrow(() -> {
+                    logger.warn("Email verification failed: Invalid token");
+                    return new BusinessException(ErrorCode.VERIFICATION_TOKEN_INVALID);
+                });
 
         // Check if already verified
         if (authUser.isEmailVerified()) {
+            logger.warn("Email verification failed: Email already verified for user {}", authUser.getId());
             throw new BusinessException(ErrorCode.EMAIL_ALREADY_VERIFIED);
         }
 
         // Check if token is expired
         if (authUser.getVerificationTokenExpiry() == null ||
                 authUser.getVerificationTokenExpiry().isBefore(Instant.now())) {
+            logger.warn("Email verification failed: Token expired for user {}", authUser.getId());
             throw new BusinessException(ErrorCode.VERIFICATION_TOKEN_EXPIRED);
         }
 
@@ -38,5 +53,19 @@ public class VerifyEmail {
         authUser.setVerificationTokenExpiry(null);
 
         authUserRepository.save(authUser);
+
+        logger.info("AUDIT: Email verified successfully for user {} (email: {})", authUser.getId(),
+                authUser.getEmail());
+
+        // Emit Kafka event
+        AuthUserEmailVerified event = AuthUserEmailVerified.newBuilder()
+                .setUserId(authUser.getId().toString())
+                .setEmail(authUser.getEmail())
+                .setVerifiedAt(
+                        com.google.protobuf.Timestamp.newBuilder().setSeconds(Instant.now().getEpochSecond()).build())
+                .build();
+
+        kafkaTemplate.send("auth.user.email.verified", authUser.getId().toString(), event.toByteArray());
+        logger.info("EmailVerified event emitted for user {}", authUser.getId());
     }
 }

--- a/services/auth-service/src/main/java/com/socialseed/authservice/auth/entry/rest/controller/AuthController.java
+++ b/services/auth-service/src/main/java/com/socialseed/authservice/auth/entry/rest/controller/AuthController.java
@@ -238,6 +238,15 @@ public class AuthController {
                                                 messageSource.getMessage("auth.verify.email.success", null, locale)));
         }
 
+        @GetMapping("/verify")
+        public ResponseEntity<ApiResponse<?>> verifyEmailViaGet(@RequestParam String token, Locale locale) {
+                authUseCases.verifyEmail(token);
+                return ResponseEntity.ok(
+                                ApiResponse.success(
+                                                null,
+                                                messageSource.getMessage("auth.verify.email.success", null, locale)));
+        }
+
         @PostMapping("/resend-verification")
         public ResponseEntity<ApiResponse<?>> resendVerificationEmail(
                         @Valid @RequestBody ResendVerificationEmailRequestDTO request,

--- a/services/auth-service/src/test/java/com/socialseed/authservice/VerifyEmailIntegrationTest.java
+++ b/services/auth-service/src/test/java/com/socialseed/authservice/VerifyEmailIntegrationTest.java
@@ -17,6 +17,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -25,107 +26,141 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 class VerifyEmailIntegrationTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+        @Autowired
+        private MockMvc mockMvc;
 
-    @Autowired
-    private AuthUserPgsqlRepository authUserRepository;
+        @Autowired
+        private AuthUserPgsqlRepository authUserRepository;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+        @Autowired
+        private ObjectMapper objectMapper;
 
-    private static final String TEST_EMAIL = "verifytest@example.com";
-    private static final String TEST_TOKEN = "valid-verification-token";
+        private static final String TEST_EMAIL = "verifytest@example.com";
+        private static final String TEST_TOKEN = "valid-verification-token";
 
-    @BeforeEach
-    void setUp() {
-        authUserRepository.deleteAll();
-    }
+        @BeforeEach
+        void setUp() {
+                authUserRepository.deleteAll();
+        }
 
-    @Test
-    void shouldVerifyEmailSuccessfully() throws Exception {
-        // Arrange
-        AuthUserPgsqlEntity user = AuthUserPgsqlEntity.builder()
-                .id(UUID.randomUUID())
-                .username("verifyuser")
-                .email(TEST_EMAIL)
-                .password("password")
-                .emailVerified(false)
-                .verificationToken(TEST_TOKEN)
-                .verificationTokenExpiry(Instant.now().plusSeconds(3600))
-                .build();
-        authUserRepository.save(user);
+        @Test
+        void shouldVerifyEmailSuccessfully() throws Exception {
+                // Arrange
+                AuthUserPgsqlEntity user = AuthUserPgsqlEntity.builder()
+                                .id(UUID.randomUUID())
+                                .username("verifyuser")
+                                .email(TEST_EMAIL)
+                                .password("password")
+                                .emailVerified(false)
+                                .verificationToken(TEST_TOKEN)
+                                .verificationTokenExpiry(Instant.now().plusSeconds(3600))
+                                .build();
+                authUserRepository.save(user);
 
-        VerifyEmailRequestDTO request = new VerifyEmailRequestDTO(TEST_TOKEN);
+                VerifyEmailRequestDTO request = new VerifyEmailRequestDTO(TEST_TOKEN);
 
-        // Act
-        mockMvc.perform(post("/auth/verify-email")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk());
+                // Act
+                mockMvc.perform(post("/auth/verify-email")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isOk());
 
-        // Assert
-        AuthUserPgsqlEntity updatedUser = authUserRepository.findByEmail(TEST_EMAIL).orElseThrow();
-        assertTrue(updatedUser.isEmailVerified());
-        assertNull(updatedUser.getVerificationToken());
-        assertNull(updatedUser.getVerificationTokenExpiry());
-    }
+                // Assert
+                AuthUserPgsqlEntity updatedUser = authUserRepository.findByEmail(TEST_EMAIL).orElseThrow();
+                assertTrue(updatedUser.isEmailVerified());
+                assertNull(updatedUser.getVerificationToken());
+                assertNull(updatedUser.getVerificationTokenExpiry());
+        }
 
-    @Test
-    void shouldFailWithInvalidToken() throws Exception {
-        // Arrange
-        VerifyEmailRequestDTO request = new VerifyEmailRequestDTO("invalid-token");
+        @Test
+        void shouldVerifyEmailViaGetEndpoint() throws Exception {
+                // Arrange
+                String getToken = "get-verification-token";
+                AuthUserPgsqlEntity user = AuthUserPgsqlEntity.builder()
+                                .id(UUID.randomUUID())
+                                .username("getverifyuser")
+                                .email("getverify@example.com")
+                                .password("password")
+                                .emailVerified(false)
+                                .verificationToken(getToken)
+                                .verificationTokenExpiry(Instant.now().plusSeconds(3600))
+                                .build();
+                authUserRepository.save(user);
 
-        // Act & Assert
-        mockMvc.perform(post("/auth/verify-email")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest());
-    }
+                // Act - Using GET /auth/verify?token=...
+                mockMvc.perform(get("/auth/verify")
+                                .param("token", getToken))
+                                .andExpect(status().isOk());
 
-    @Test
-    void shouldFailWithExpiredToken() throws Exception {
-        // Arrange
-        AuthUserPgsqlEntity user = AuthUserPgsqlEntity.builder()
-                .id(UUID.randomUUID())
-                .username("verifyuser")
-                .email(TEST_EMAIL)
-                .password("password")
-                .emailVerified(false)
-                .verificationToken(TEST_TOKEN)
-                .verificationTokenExpiry(Instant.now().minusSeconds(3600)) // Expired
-                .build();
-        authUserRepository.save(user);
+                // Assert
+                AuthUserPgsqlEntity updatedUser = authUserRepository.findByEmail("getverify@example.com").orElseThrow();
+                assertTrue(updatedUser.isEmailVerified());
+                assertNull(updatedUser.getVerificationToken());
+        }
 
-        VerifyEmailRequestDTO request = new VerifyEmailRequestDTO(TEST_TOKEN);
+        @Test
+        void shouldFailWithInvalidToken() throws Exception {
+                // Arrange
+                VerifyEmailRequestDTO request = new VerifyEmailRequestDTO("invalid-token");
 
-        // Act & Assert
-        mockMvc.perform(post("/auth/verify-email")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest());
-    }
+                // Act & Assert
+                mockMvc.perform(post("/auth/verify-email")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isBadRequest());
+        }
 
-    @Test
-    void shouldFailIfAlreadyVerified() throws Exception {
-        // Arrange
-        AuthUserPgsqlEntity user = AuthUserPgsqlEntity.builder()
-                .id(UUID.randomUUID())
-                .username("verifyuser")
-                .email(TEST_EMAIL)
-                .password("password")
-                .emailVerified(true) // Already verified
-                .verificationToken(TEST_TOKEN)
-                .verificationTokenExpiry(Instant.now().plusSeconds(3600))
-                .build();
-        authUserRepository.save(user);
+        @Test
+        void shouldFailWithInvalidTokenViaGet() throws Exception {
+                // Act & Assert - GET endpoint with invalid token
+                mockMvc.perform(get("/auth/verify")
+                                .param("token", "invalid-get-token"))
+                                .andExpect(status().isBadRequest());
+        }
 
-        VerifyEmailRequestDTO request = new VerifyEmailRequestDTO(TEST_TOKEN);
+        @Test
+        void shouldFailWithExpiredToken() throws Exception {
+                // Arrange
+                AuthUserPgsqlEntity user = AuthUserPgsqlEntity.builder()
+                                .id(UUID.randomUUID())
+                                .username("verifyuser")
+                                .email(TEST_EMAIL)
+                                .password("password")
+                                .emailVerified(false)
+                                .verificationToken(TEST_TOKEN)
+                                .verificationTokenExpiry(Instant.now().minusSeconds(3600)) // Expired
+                                .build();
+                authUserRepository.save(user);
 
-        // Act & Assert
-        mockMvc.perform(post("/auth/verify-email")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest());
-    }
+                VerifyEmailRequestDTO request = new VerifyEmailRequestDTO(TEST_TOKEN);
+
+                // Act & Assert
+                mockMvc.perform(post("/auth/verify-email")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void shouldFailIfAlreadyVerified() throws Exception {
+                // Arrange
+                AuthUserPgsqlEntity user = AuthUserPgsqlEntity.builder()
+                                .id(UUID.randomUUID())
+                                .username("verifyuser")
+                                .email(TEST_EMAIL)
+                                .password("password")
+                                .emailVerified(true) // Already verified
+                                .verificationToken(TEST_TOKEN)
+                                .verificationTokenExpiry(Instant.now().plusSeconds(3600))
+                                .build();
+                authUserRepository.save(user);
+
+                VerifyEmailRequestDTO request = new VerifyEmailRequestDTO(TEST_TOKEN);
+
+                // Act & Assert
+                mockMvc.perform(post("/auth/verify-email")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isBadRequest());
+        }
 }

--- a/verify_services/verify_auth_flow.py
+++ b/verify_services/verify_auth_flow.py
@@ -402,7 +402,83 @@ def run_verification():
         print(f"  FATAL: Could not query SocialUser service. Status: {resp.status_code}")
         sys.exit(1)
 
+    # 14. Verify Email Workflow (Issue #66)
+    print("\n14. Verify Email Workflow (Issue #66)")
+    
+    # Create a new user specifically for this test
+    VERIFY_EMAIL = f"verify_{int(time.time())}@test.com"
+    VERIFY_USER = f"verifyuser_{int(time.time()) % 10000}"
+    print(f"  Registering user {VERIFY_USER} ({VERIFY_EMAIL})...")
+    resp = requests.post(f"{BASE_URL}/register", json={
+        "username": VERIFY_USER,
+        "email": VERIFY_EMAIL,
+        "password": INITIAL_PASSWORD
+    })
+    if resp.status_code not in [200, 201]:
+        print(f"  FATAL: Registration failed. Status: {resp.status_code}, Body: {resp.text}")
+        sys.exit(1)
+    print("  Registration successful.")
+
+    # Fetch verification token from DB
+    print("  Fetching verification token from DB via SQL...")
+    get_token_sql = f"SELECT verification_token FROM auth_users WHERE email = '{VERIFY_EMAIL}';"
+    try:
+        token_out = subprocess.run(["psql", "-U", "authuser", "-d", "authdb", "-h", "localhost", "-t", "-c", get_token_sql], 
+                       env={"PGPASSWORD": "authpass"}, check=True, capture_output=True, text=True)
+        verify_token = token_out.stdout.strip()
+        if not verify_token or verify_token == "no":
+            print("  FATAL: Could not find verification token in DB.")
+            sys.exit(1)
+        print(f"  Found token: {verify_token[:5]}...")
+    except Exception as e:
+        print(f"  FATAL: SQL error fetching token: {e}")
+        sys.exit(1)
+
+    # Test GET /auth/verify?token=... (Issue #66 requirement)
+    print("  Testing GET /auth/verify?token=... endpoint...")
+    resp = requests.get(f"{BASE_URL}/verify", params={"token": verify_token})
+    if resp.status_code == 200:
+        print("  Email verification via GET successful.")
+    else:
+        print(f"  FATAL: GET verify failed. Status: {resp.status_code}, Body: {resp.text}")
+        sys.exit(1)
+
+    # Verify user is now marked as verified in DB
+    print("  Verifying emailVerified flag in DB...")
+    check_sql = f"SELECT email_verified FROM auth_users WHERE email = '{VERIFY_EMAIL}';"
+    try:
+        check_out = subprocess.run(["psql", "-U", "authuser", "-d", "authdb", "-h", "localhost", "-t", "-c", check_sql], 
+                       env={"PGPASSWORD": "authpass"}, check=True, capture_output=True, text=True)
+        is_verified = check_out.stdout.strip()
+        if is_verified == "t":
+            print("  SUCCESS: emailVerified = true in database.")
+        else:
+            print(f"  FATAL: emailVerified is not true. Value: {is_verified}")
+            sys.exit(1)
+    except Exception as e:
+        print(f"  FATAL: SQL error checking emailVerified: {e}")
+        sys.exit(1)
+
+    # Test invalid token (should return 400)
+    print("  Testing invalid token (should return 400)...")
+    resp = requests.get(f"{BASE_URL}/verify", params={"token": "invalid-fake-token"})
+    if resp.status_code == 400:
+        print("  SUCCESS: Invalid token correctly rejected with 400.")
+    else:
+        print(f"  ERROR: Expected 400 for invalid token, got {resp.status_code}")
+        sys.exit(1)
+
+    # Test already verified (should return 400)
+    print("  Testing already verified user (should return 400)...")
+    resp = requests.get(f"{BASE_URL}/verify", params={"token": verify_token})
+    if resp.status_code == 400:
+        print("  SUCCESS: Already verified user correctly rejected with 400.")
+    else:
+        print(f"  ERROR: Expected 400 for already verified, got {resp.status_code}")
+        sys.exit(1)
+
     print("\n--- ALL TESTS COMPLETED SUCCESSFULLY ---")
+
 
 if __name__ == "__main__":
     if wait_for_service():


### PR DESCRIPTION
- Added GET /auth/verify?token=... endpoint for clickable email links.
- Emit AuthUserEmailVerified Kafka event on successful verification.
- Added comprehensive audit logging (INFO for success, WARN for failures).
- Standardized error codes: VERIFICATION_TOKEN_INVALID, VERIFICATION_TOKEN_EXPIRED, EMAIL_ALREADY_VERIFIED.
- Added integration tests for both GET and POST endpoints.
- Added E2E verification in verify_auth_flow.py.

For more detailed information about the implementation, please refer to the summary at: docs/summaries/issue-66-verify-email-workflow-summary.md